### PR TITLE
PR to use 'any' type for placeholder in MaterialEditable

### DIFF
--- a/src/slate-react/MaterialEditable.jsx
+++ b/src/slate-react/MaterialEditable.jsx
@@ -99,7 +99,7 @@ MaterialEditable.propTypes = {
   /** Called when a leaf needs to be rendered */
   renderLeaf: PropTypes.func,
   /** Text to display when there are no contents on the editor. Default" "Type some text..." */
-  placeholder: PropTypes.string,
+  placeholder: PropTypes.any,
   /**
    * Additional hotkeys to be added other than default. Object of the form `{'mod+k': {type: 'mark', value: 'italic'}
    * defaultHotkeys can be disallowed by passing hotkeys as null

--- a/src/slate-react/MaterialEditable.jsx
+++ b/src/slate-react/MaterialEditable.jsx
@@ -98,7 +98,7 @@ MaterialEditable.propTypes = {
   renderElement: PropTypes.func,
   /** Called when a leaf needs to be rendered */
   renderLeaf: PropTypes.func,
-  /** Text to display when there are no contents on the editor. Default" "Type some text..." */
+  /** Text/component to display when there are no contents on the editor. Default" "Type some text..." */
   placeholder: PropTypes.any,
   /**
    * Additional hotkeys to be added other than default. Object of the form `{'mod+k': {type: 'mark', value: 'italic'}


### PR DESCRIPTION
Placeholder property can be used as text, numbers or even components. When not using text, a warning is thrown for being not the correct type. This change prevents the warning to appear